### PR TITLE
fix: Liquibase 变更集 type="BIT(1)" 导致 PostgreSQL 启动失败

### DIFF
--- a/starter/src/main/resources/db/changelog/migration/260812_add_robot_settings_ai_disclaimer.xml
+++ b/starter/src/main/resources/db/changelog/migration/260812_add_robot_settings_ai_disclaimer.xml
@@ -11,6 +11,9 @@
         背景：RobotBubble 原本无条件显示免责声明，现支持在 RobotSettings 中控制开关和自定义文案。
     -->
     <changeSet id="260812-1-add-robot-settings-hide-ai-disclaimer" author="copilot">
+        <!-- type 改用 Liquibase 抽象类型 BOOLEAN: MySQL 上映射为 BIT(1) (行为不变), PostgreSQL 映射为 BOOLEAN,
+             写死 BIT(1) 会导致 PG 上 "column is of type bit but default expression is of type boolean" 启动失败 -->
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <tableExists tableName="bytedesk_ai_robot_settings"/>
             <not>
@@ -18,7 +21,7 @@
             </not>
         </preConditions>
         <addColumn tableName="bytedesk_ai_robot_settings">
-            <column name="hide_ai_disclaimer" type="BIT(1)" defaultValueBoolean="false">
+            <column name="hide_ai_disclaimer" type="BOOLEAN" defaultValueBoolean="false">
                 <constraints nullable="false"/>
             </column>
         </addColumn>

--- a/starter/src/main/resources/db/changelog/migration/260812_add_workgroup_settings_ai_disclaimer.xml
+++ b/starter/src/main/resources/db/changelog/migration/260812_add_workgroup_settings_ai_disclaimer.xml
@@ -12,6 +12,9 @@
         字段挂在 WorkgroupSettingsEntity 顶层（与 RobotSettingsEntity 对称），不放入共享的 ServiceSettingsEntity。
     -->
     <changeSet id="260812-4-add-workgroup-settings-hide-ai-disclaimer" author="copilot">
+        <!-- type 改用 Liquibase 抽象类型 BOOLEAN: MySQL 上映射为 BIT(1) (行为不变), PostgreSQL 映射为 BOOLEAN,
+             写死 BIT(1) 会导致 PG 上 "column is of type bit but default expression is of type boolean" 启动失败 -->
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <tableExists tableName="bytedesk_service_workgroup_settings"/>
             <not>
@@ -19,7 +22,7 @@
             </not>
         </preConditions>
         <addColumn tableName="bytedesk_service_workgroup_settings">
-            <column name="hide_ai_disclaimer" type="BIT(1)" defaultValueBoolean="false">
+            <column name="hide_ai_disclaimer" type="BOOLEAN" defaultValueBoolean="false">
                 <constraints nullable="false"/>
             </column>
         </addColumn>

--- a/starter/src/main/resources/db/changelog/migration/260909_add_ticket_auto_create_time_window_fields.xml
+++ b/starter/src/main/resources/db/changelog/migration/260909_add_ticket_auto_create_time_window_fields.xml
@@ -14,6 +14,10 @@
         时间段外的关闭事件直接跳过、不补建。
     -->
     <changeSet id="260909-1-add-ticket-auto-create-time-window-enabled" author="copilot">
+        <!-- type 改用 Liquibase 抽象类型 BOOLEAN: MySQL 上映射为 BIT(1) (行为不变), PostgreSQL 映射为 BOOLEAN。
+             原写死的 BIT(1) 在 PostgreSQL 上生成 "ADD COLUMN ... BIT(1) DEFAULT FALSE NOT NULL",
+             报错 "column is of type bit but default expression is of type boolean", 导致 4.4.5 在 PG 上启动失败。 -->
+        <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <tableExists tableName="bytedesk_ticket_auto_create_settings"/>
             <not>
@@ -21,7 +25,7 @@
             </not>
         </preConditions>
         <addColumn tableName="bytedesk_ticket_auto_create_settings">
-            <column name="time_window_enabled" type="BIT(1)" defaultValueBoolean="false">
+            <column name="time_window_enabled" type="BOOLEAN" defaultValueBoolean="false">
                 <constraints nullable="false"/>
             </column>
         </addColumn>


### PR DESCRIPTION
## 问题

4.4.5 在 PostgreSQL 上启动失败，Liquibase 执行时报错：

```
ERROR: column "time_window_enabled" is of type bit but default expression is of type boolean
STATEMENT: ALTER TABLE public.bytedesk_ticket_auto_create_settings ADD time_window_enabled BIT(1) DEFAULT FALSE NOT NULL
```

`type="BIT(1)"` 是 MySQL 方言写法，在 PostgreSQL 上生成 `bit` 类型，与 `defaultValueBoolean="false"` 生成的 boolean 默认值不兼容（PG 中 `bit` 与 `boolean` 是不同类型）。MySQL 上一切正常，因此未被发现。

## 修复

统一修复 3 个同类变更集：

| 文件 | changeSet | 影响 |
|---|---|---|
| 260909_add_ticket_auto_create_time_window_fields.xml | 260909-1 | 4.4.5 新增，PG 上必现启动失败 |
| 260812_add_workgroup_settings_ai_disclaimer.xml | 260812-4 | 全新 PG 库上会失败 |
| 260812_add_robot_settings_ai_disclaimer.xml | 260812-1 | 同上 |

改法：

1. `type="BIT(1)"` → `type="BOOLEAN"`：Liquibase 抽象类型按方言映射——MySQL → `BIT(1)`（生成 DDL 不变，行为完全兼容），PostgreSQL → `BOOLEAN`，Oracle → `NUMBER(1)`
2. 增加 `<validCheckSum>ANY</validCheckSum>`：这些变更集已随 4.4.x 发布，直接修改会使已执行过它们的部署（MySQL）因校验和失配而启动失败，`ANY` 使旧记录继续被接受

## 验证

- PostgreSQL 17 + 4.4.5 实测：修复前启动即崩（上述报错）；按本修复的等效 DDL 将列建为 `boolean` 后启动成功，应用正常运行
- MySQL 语义不变（`BOOLEAN` 在 MySQL 上仍生成 `BIT(1)`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)