### PR TITLE
fix: loadUserByUsername 未命中时回退按 email 查找，修复第三方登录用户 401

### DIFF
--- a/modules/core/src/main/java/com/bytedesk/core/rbac/user/UserDetailsServiceImpl.java
+++ b/modules/core/src/main/java/com/bytedesk/core/rbac/user/UserDetailsServiceImpl.java
@@ -68,6 +68,10 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 		// 
 		Optional<UserEntity> userOptional = findByUsernameAndPlatform(username, PlatformEnum.BYTEDESK.name());
 		if (!userOptional.isPresent()) {
+			// 回退按 email 查找: 第三方登录(CAS/OIDC等)注册的用户, JWT subject 中的 username 可能是 email
+			userOptional = findByEmailAndPlatform(username, PlatformEnum.BYTEDESK.name());
+		}
+		if (!userOptional.isPresent()) {
 			throw new UsernameNotFoundException("username " + username + " is not found");
 		}
 		if (!userOptional.get().isEnabled()) {
@@ -80,6 +84,10 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 		log.debug("loadUserByUsernameAndPlatform username: {}, platform: {}", username, platform);
 		//
 		Optional<UserEntity> userOptional = findByUsernameAndPlatform(username, platform);
+		if (!userOptional.isPresent()) {
+			// 回退按 email 查找: 第三方登录(CAS/OIDC等)注册的用户, JWT subject 中的 username 可能是 email
+			userOptional = findByEmailAndPlatform(username, platform);
+		}
 		if (!userOptional.isPresent()) {
 			throw new UsernameNotFoundException("username " + username + " is not found");
 		}
@@ -95,6 +103,10 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 		// log.debug("loadUserByUsername {}, username {}, platform {}", subject, username, platform);
 		//
 		Optional<UserEntity> userOptional = findByUsernameAndPlatform(username, PlatformEnum.fromValue(platform).name());
+		if (!userOptional.isPresent()) {
+			// 回退按 email 查找: 第三方登录(CAS/OIDC等)注册的用户, JWT subject 中的 username 可能是 email
+			userOptional = findByEmailAndPlatform(username, PlatformEnum.fromValue(platform).name());
+		}
 		if (!userOptional.isPresent()) {
 			throw new UsernameNotFoundException("username " + username + " is not found");
 		}


### PR DESCRIPTION
## 问题

第三方登录（CAS / OIDC 等，企业模块）自动注册的用户，JWT 认证时报 401：

```
UsernameNotFoundException: username xxx@domain is not found
```

场景：第三方登录控制器注册用户时 `username=第三方账号`（如学工号）、`email=账号@default-email-domain`；而签发 JWT 时对有 email 的用户将 **email** 写入 subject 的 username 字段（企业模块行为）。认证侧 `UserDetailsServiceImpl` 的三个 username 加载方法只查 `username` 列，永远查不到这类用户。

## 修复

`loadUserByUsername` / `loadUserByUsernameAndPlatform`（两个重载）在 username 未命中时**回退按 email 查找**：

- 复用现有 `findByEmailAndPlatform`（`@Cacheable`，`deleted=false` 过滤）
- 回退命中后仍走原有 `isEnabled()` 检查与 `UserDetailsImpl.build`
- username 精确命中的原有路径完全不受影响（仅未命中时多一次查询）
- 使"有 email 的用户 username 列=username"与"username 列=email"两种存量数据都能认证通过

对应的 CAS 场景 issue 随后提交（企业模块 CasAuthController 侧的注册时 username 对齐问题），本 PR 让 core 侧对两类数据兼容。

🤖 Generated with [Claude Code](https://claude.com/claude-code)